### PR TITLE
Fix yardasol tweaks

### DIFF
--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -578,10 +578,11 @@ class Integrator(ABC):
             * ``n1`` is a :class:`numpy.ndarray` of compositions at the
               next time step. Expected to be of the same shape as ``n0``
 
-        .. versionadded:: 0.13.3
     msr_continuous : openmc.deplete.msr.MsrContinuous
         Instance of MsrContinuous class to perform msr continuous removal based
         on removal rates definitions.
+
+        .. versionadded:: 0.13.3
 
     """
 

--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -723,8 +723,8 @@ class Chain:
             # Build removal terms matrices
             if isinstance(materials, str):
                 material = materials
-                if element in msr.get_elements(mat):
-                    matrix[i, i] = msr.get_removal_rate(mat, elm)
+                if element in msr.get_elements(material):
+                    matrix[i, i] = msr.get_removal_rate(material, element)
                 else:
                     matrix[i, i] = 0.0
             #Build transfer terms matrices
@@ -733,7 +733,7 @@ class Chain:
                 if msr.get_destination_material(material, element) == destination_material:
                     matrix[i, i] = msr.get_removal_rate(material, element)
                 else:
-                    warn(f'Material {desination_material} is not defined '
+                    warn(f'Material {destination_material} is not defined '
                          f'as a destination material for Material {material}. '
                          'Setting removal rate to 0.0')
                     matrix[i, i] = 0.0

--- a/openmc/deplete/msr.py
+++ b/openmc/deplete/msr.py
@@ -117,7 +117,7 @@ class MsrContinuous:
             Depletable material ID to where the element gets transferred
 
         """
-        material_id = self._get_material_id(mat)
+        material_id = self._get_material_id(material)
         check_value('element', element, ELEMENT_SYMBOL.values())
         if element in self.removal_rates[material_id]:
             return self.removal_rates[material_id][element][1]
@@ -170,6 +170,8 @@ class MsrContinuous:
             else:
                 raise ValueError(f'Transfer to material {destination_material_id} '\
                         'is set, but there is only one depletable material')
+        else:
+            destination_material_id = None
 
         if removal_rate_units in ('1/s', '1/sec'):
             unit_conv = 1

--- a/openmc/deplete/pool.py
+++ b/openmc/deplete/pool.py
@@ -82,25 +82,23 @@ def deplete(func, chain, x, rates, dt, matrix_func=None, msr=None):
             rows_cols = \
                 np.array(np.meshgrid(range(n_rows),
                                      range(n_cols))).T.reshape(-1, 2)
-            prev_row = 0
+            last_col = n_cols - 1
             cols = []
-            for (row, col) in rows_cols
-                if row != prev_row:
-                    rows.append(cols)
-                    cols = []
-                    prev_row = row
+            for (row, col) in rows_cols:
                 if row == col:
                     # Fill the diagonals with the Bateman matrices
                     cols.append(matrices[row])
                 elif (msr.burnable_mats[row], msr.burnable_mats[col]) in \
                                 msr.index_transfer:
-
                     index = list(msr.index_transfer).index( \
                                 (msr.burnable_mats[row], msr.burnable_mats[col]))
                     # Fill the off-diagonals with the transfer matrices
                     cols.append(transfers[index])
                 else:
                     cols.append(None)
+                if col == last_col:
+                    rows.append(cols)
+                    cols = []
             matrix = bmat(rows)
 
             # Concatenate vectors of nuclides in one

--- a/tests/unit_tests/test_deplete_msr_continuous.py
+++ b/tests/unit_tests/test_deplete_msr_continuous.py
@@ -59,30 +59,30 @@ def test_get_set(model):
     dest_material_inputs = [dest_material,
                             dest_material.name,
                             dest_material.id]
-    material_inputs = np.array(np.meshgrid(material_inputs
+    material_inputs = np.array(np.meshgrid(material_inputs,
                                      dest_material_inputs)).T.reshape(-1, 2)
     for material_input, dest_material_input in material_inputs:
         for element, removal_rate in removal_rates.items():
             msr.set_removal_rate(material_input, [element], removal_rate,
                                  destination_material=dest_material_input)
             assert msr.get_removal_rate(material_input, element) == removal_rate
-            assert msr.get_destination_material(material_input, element) == str(dest_mat.id)
+            assert msr.get_destination_material(material_input, element) == str(dest_material.id)
         assert msr.get_elements(material_input) == removal_rates.keys()
 
-@pytest.mark.parametrize("removal_rate_units, units_per_seconds", [
+@pytest.mark.parametrize("removal_rate_units, unit_conv", [
     ('1/s', 1),
     ('1/sec', 1),
-    ('1/min', 1/_SECONDS_PER_MINUTE),
-    ('1/minute', 1/_SECONDS_PER_MINUTE),
-    ('1/h', 1/_SECONDS_PER_HOUR),
-    ('1/hr', 1/_SECONDS_PER_HOUR),
-    ('1/hour', 1/_SECONDS_PER_HOUR),
-    ('1/d', 1/_SECONDS_PER_DAY),
-    ('1/day', 1/_SECONDS_PER_DAY),
-    ('1/a', 1/_SECONDS_PER_JULIAN_YEAR),
-    ('1/year', 1/_SECONDS_PER_JULIAN_YEAR),
+    ('1/min', _SECONDS_PER_MINUTE),
+    ('1/minute', _SECONDS_PER_MINUTE),
+    ('1/h', _SECONDS_PER_HOUR),
+    ('1/hr', _SECONDS_PER_HOUR),
+    ('1/hour', _SECONDS_PER_HOUR),
+    ('1/d', _SECONDS_PER_DAY),
+    ('1/day', _SECONDS_PER_DAY),
+    ('1/a', _SECONDS_PER_JULIAN_YEAR),
+    ('1/year', _SECONDS_PER_JULIAN_YEAR),
     ])
-def test_units(removal_rate_units, units_per_seconds, model):
+def test_units(removal_rate_units, unit_conv, model):
     """ Units testing"""
     # create removal rate Xe
     element = 'Xe'
@@ -90,7 +90,7 @@ def test_units(removal_rate_units, units_per_seconds, model):
     op = CoupledOperator(model, CHAIN_PATH)
     msr = MsrContinuous(op, model)
 
-    msr.set_removal_rate('f', [element], removal_rate*units_per_seconds,
+    msr.set_removal_rate('f', [element], removal_rate * unit_conv,
                          removal_rate_units=removal_rate_units)
     assert msr.get_removal_rate('f', element) == removal_rate
 


### PR DESCRIPTION
@church89 This fixes everything except the `depletion_with_removal` case, for which I get the following error using the nndc cross section library
```python
______________ test_msr[True-False-174.0-depletion_with_removal] _______________

run_in_tmpdir = None
model = <openmc.model.model.Model object at 0x7fb8bc74bfa0>, removal = True
feed = False, power = 174.0, ref_result = 'depletion_with_removal'

    @pytest.mark.parametrize("removal, feed, power, ref_result", [
        (True, False, 0.0, 'no_depletion_only_removal'),
        (False, True, 0.0, 'no_depletion_only_feed'),
        (True, False, 174.0, 'depletion_with_removal'),
        (False, True, 174.0, 'depletion_with_feed'),
        (True, True, 0.0, 'no_depletion_with_feed_and_removal'),
        (True, True, 174.0, 'depletion_with_feed_and_removal'),
        ])
    def test_msr(run_in_tmpdir, model, removal, feed, power, ref_result):
        """Tests msr depletion class with removal rates"""
    
        chain_file = Path(__file__).parents[2] / 'chain_simple.xml'
    
        # Defining removing and feeding elements, using the same removal rate
        removing_element = ['Xe']
        feeding_element = ['U']
        removal_rate = 1e-5
    
        op = CoupledOperator(model, chain_file)
        msr = MsrContinuous(op, model)
        if removal:
            msr.set_removal_rate('f', removing_element, removal_rate,
                                destination_material=None)
        if feed:
            msr.set_removal_rate('f', feeding_element, removal_rate,
                                destination_material='w')
        integrator = openmc.deplete.PredictorIntegrator(
            op, [1], power, msr_continuous = msr, timestep_units = 'd')
        integrator.integrate()
    
        # Get path to test and reference results
        path_test = op.output_dir / 'depletion_results.h5'
        path_reference = Path(__file__).with_name(f'ref_msr_{ref_result}.h5')
    
        # Load the reference/test results
        res_ref = openmc.deplete.Results(path_reference)
        res_test = openmc.deplete.Results(path_test)
    
        for mat in res_test[0].rates[0].index_mat:
            for nuc in res_test[0].rates[0].index_nuc:
                for rx in res_test[0].rates[0].index_rx:
                    y_test = res_test.get_reaction_rate(mat, nuc, rx)[1] / \
                        res_test.get_atoms(mat, nuc)[1]
                    y_ref = res_ref.get_reaction_rate(mat, nuc, rx)[1] / \
                        res_ref.get_atoms(mat, nuc)[1]
>                   assert y_test == pytest.approx(y_ref, abs=1e-6)
E                   assert array([4.1863....0655120e-05]) == approx([4.097...05 ± 1.0e-06])
E                     comparison failed. Mismatched elements: 1 / 2:
E                     Max absolute difference: 1.2592162812261805e-06
E                     Max relative difference: 0.030973129109841794
E                     Index | Obtained             | Expected                        
E                     (1,)  | 4.06551200158224e-05 | 3.9395903734596217e-05 ± 1.0e-06

/home/ooblack/projects/openmc/tests/regression_tests/deplete_msr_continuous/test.py:89: AssertionError
```
What cross section library did you use to create this case?