### PR TITLE
Fix std keff check batchwise

### DIFF
--- a/openmc/deplete/batchwise.py
+++ b/openmc/deplete/batchwise.py
@@ -254,13 +254,13 @@ class Batchwise(ABC):
                     print("Search_for_keff returned values below or above "
                           "target. Trying to iteratively adapt bracket...")
 
-                    # if the bracket ends up being smaller than the std of the
-                    # keff's closer value to target, no need to continue-
+                    # if the retured keffs range ends up being smaller than the
+                    # max keff std deviation, set closest value and continue
                     if all(abs(keff-self.target) <= max(keffs).s for keff in keffs):
                         arg_min = abs(self.target - np.array(keffs)).argmin()
-                        print("Search_for_keff returned values with std below "
-                              "the current deviation to target. Set root to "
-                              "closest value and continue...")
+                        print("Search_for_keff returned keffs range smaller than"
+                              "max std dev. Set root to guess with "
+                              "closest keff to target and continue...")
                         root = guesses[arg_min]
 
                     # Calculate gradient as ratio of delta bracket and delta keffs

--- a/openmc/deplete/batchwise.py
+++ b/openmc/deplete/batchwise.py
@@ -256,8 +256,11 @@ class Batchwise(ABC):
 
                     # if the bracket ends up being smaller than the std of the
                     # keff's closer value to target, no need to continue-
-                    if all(keff <= max(keffs).s for keff in keffs):
-                        arg_min = abs(self.target - np.array(guesses)).argmin()
+                    if all(abs(keff-self.target) <= max(keffs).s for keff in keffs):
+                        arg_min = abs(self.target - np.array(keffs)).argmin()
+                        print("Search_for_keff returned values with std below "
+                              "the current deviation to target. Set root to "
+                              "closest value and continue...")
                         root = guesses[arg_min]
 
                     # Calculate gradient as ratio of delta bracket and delta keffs


### PR DESCRIPTION
This PR fixes an old bug during iteratively `search_for_keff` routine. Specifically, when returned keffs range end up being smaller than max keff std dev, there is no need to adapt the bracket as it is already smaller than current statistical uncertainty. Thus, the guess value with the closest keff to target will be set as root. 